### PR TITLE
Make gc patch symbols public in 1.9.3-p125 for ruby-prof memory profiles

### DIFF
--- a/patches/ruby/1.9.3/p125/railsexpress/02-railsbench-gc.patch
+++ b/patches/ruby/1.9.3/p125/railsexpress/02-railsbench-gc.patch
@@ -234,7 +234,7 @@ index e65d0ec..74ebec6 100644
  }
  
  #if defined(ENABLE_VM_OBJSPACE) && ENABLE_VM_OBJSPACE
-@@ -753,6 +868,11 @@ vm_malloc_fixup(rb_objspace_t *objspace, void *mem, size_t size)
+@@ -754,6 +869,11 @@ vm_malloc_fixup(rb_objspace_t *objspace, void *mem, size_t size)
      mem = (size_t *)mem + 1;
  #endif
  
@@ -246,7 +246,7 @@ index e65d0ec..74ebec6 100644
      return mem;
  }
  
-@@ -813,6 +933,13 @@ vm_xrealloc(rb_objspace_t *objspace, void *ptr, size_t size)
+@@ -814,6 +934,13 @@ vm_xrealloc(rb_objspace_t *objspace, void *ptr, size_t size)
      mem = (size_t *)mem + 1;
  #endif
  
@@ -260,7 +260,7 @@ index e65d0ec..74ebec6 100644
      return mem;
  }
  
-@@ -894,7 +1021,6 @@ ruby_xfree(void *x)
+@@ -895,7 +1022,6 @@ ruby_xfree(void *x)
  	vm_xfree(&rb_objspace, x);
  }
  
@@ -268,7 +268,7 @@ index e65d0ec..74ebec6 100644
  /*
   *  call-seq:
   *     GC.enable    -> true or false
-@@ -940,6 +1066,455 @@ rb_gc_disable(void)
+@@ -941,6 +1067,458 @@ rb_gc_disable(void)
      return old ? Qtrue : Qfalse;
  }
  
@@ -366,6 +366,7 @@ index e65d0ec..74ebec6 100644
 + *
 + */
 +
++RUBY_FUNC_EXPORTED
 +VALUE
 +rb_gc_allocated_size()
 +{
@@ -692,6 +693,7 @@ index e65d0ec..74ebec6 100644
 + *
 + */
 +
++RUBY_FUNC_EXPORTED
 +VALUE
 +rb_gc_collections()
 +{
@@ -710,6 +712,7 @@ index e65d0ec..74ebec6 100644
 + *
 + */
 +
++RUBY_FUNC_EXPORTED
 +VALUE
 +rb_gc_time()
 +{
@@ -724,7 +727,7 @@ index e65d0ec..74ebec6 100644
  VALUE rb_mGC;
  
  void
-@@ -1011,6 +1586,12 @@ allocate_sorted_heaps(rb_objspace_t *objspace, size_t next_heaps_length)
+@@ -1012,6 +1587,12 @@ allocate_sorted_heaps(rb_objspace_t *objspace, size_t next_heaps_length)
  static void
  assign_heap_slot(rb_objspace_t *objspace)
  {
@@ -737,7 +740,7 @@ index e65d0ec..74ebec6 100644
      RVALUE *p, *pend, *membase;
      struct heaps_slot *slot;
      size_t hi, lo, mid;
-@@ -1072,6 +1653,7 @@ assign_heap_slot(rb_objspace_t *objspace)
+@@ -1073,6 +1654,7 @@ assign_heap_slot(rb_objspace_t *objspace)
      if (lomem == 0 || lomem > p) lomem = p;
      if (himem < pend) himem = pend;
      heaps_used++;
@@ -745,7 +748,7 @@ index e65d0ec..74ebec6 100644
  
      while (p < pend) {
  	p->as.free.flags = 0;
-@@ -1127,7 +1709,7 @@ initial_expand_heap(rb_objspace_t *objspace)
+@@ -1128,7 +1710,7 @@ initial_expand_heap(rb_objspace_t *objspace)
  static void
  set_heaps_increment(rb_objspace_t *objspace)
  {
@@ -754,7 +757,7 @@ index e65d0ec..74ebec6 100644
  
      if (next_heaps_length == heaps_used) {
          next_heaps_length++;
-@@ -1160,6 +1742,22 @@ rb_during_gc(void)
+@@ -1161,6 +1743,22 @@ rb_during_gc(void)
  
  #define RANY(o) ((RVALUE*)(o))
  
@@ -777,7 +780,7 @@ index e65d0ec..74ebec6 100644
  VALUE
  rb_newobj(void)
  {
-@@ -1191,9 +1789,11 @@ rb_newobj(void)
+@@ -1192,9 +1790,11 @@ rb_newobj(void)
  
      MEMZERO((void*)obj, RVALUE, 1);
  #ifdef GC_DEBUG
@@ -790,7 +793,7 @@ index e65d0ec..74ebec6 100644
      GC_PROF_INC_LIVE_NUM;
  
      return obj;
-@@ -1660,6 +2260,12 @@ gc_mark_children(rb_objspace_t *objspace, VALUE ptr, int lev)
+@@ -1661,6 +2261,12 @@ gc_mark_children(rb_objspace_t *objspace, VALUE ptr, int lev)
  {
      register RVALUE *obj = RANY(ptr);
  
@@ -803,7 +806,7 @@ index e65d0ec..74ebec6 100644
      goto marking;		/* skip */
  
    again:
-@@ -1670,6 +2276,12 @@ gc_mark_children(rb_objspace_t *objspace, VALUE ptr, int lev)
+@@ -1671,6 +2277,12 @@ gc_mark_children(rb_objspace_t *objspace, VALUE ptr, int lev)
      obj->as.basic.flags |= FL_MARK;
      objspace->heap.live_num++;
  
@@ -816,7 +819,7 @@ index e65d0ec..74ebec6 100644
    marking:
      if (FL_TEST(obj, FL_EXIVAR)) {
  	rb_mark_generic_ivar(ptr);
-@@ -2012,6 +2624,25 @@ free_unused_heaps(rb_objspace_t *objspace)
+@@ -2013,6 +2625,25 @@ free_unused_heaps(rb_objspace_t *objspace)
      }
  }
  
@@ -842,7 +845,7 @@ index e65d0ec..74ebec6 100644
  static void
  slot_sweep(rb_objspace_t *objspace, struct heaps_slot *sweep_slot)
  {
-@@ -2019,14 +2650,23 @@ slot_sweep(rb_objspace_t *objspace, struct heaps_slot *sweep_slot)
+@@ -2020,14 +2651,23 @@ slot_sweep(rb_objspace_t *objspace, struct heaps_slot *sweep_slot)
      RVALUE *p, *pend;
      RVALUE *free = freelist, *final = deferred_final_list;
      int deferred;
@@ -866,7 +869,7 @@ index e65d0ec..74ebec6 100644
                      p->as.free.flags = T_ZOMBIE;
                      RDATA(p)->dfree = 0;
                  }
-@@ -2036,6 +2676,10 @@ slot_sweep(rb_objspace_t *objspace, struct heaps_slot *sweep_slot)
+@@ -2037,6 +2677,10 @@ slot_sweep(rb_objspace_t *objspace, struct heaps_slot *sweep_slot)
                  final_num++;
              }
              else {
@@ -877,7 +880,7 @@ index e65d0ec..74ebec6 100644
                  add_freelist(objspace, p);
                  free_num++;
              }
-@@ -2043,13 +2687,22 @@ slot_sweep(rb_objspace_t *objspace, struct heaps_slot *sweep_slot)
+@@ -2044,13 +2688,22 @@ slot_sweep(rb_objspace_t *objspace, struct heaps_slot *sweep_slot)
          else if (BUILTIN_TYPE(p) == T_ZOMBIE) {
              /* objects to be finalized */
              /* do nothing remain marked */
@@ -901,7 +904,7 @@ index e65d0ec..74ebec6 100644
          objspace->heap.free_num > objspace->heap.do_heap_free) {
          RVALUE *pp;
  
-@@ -2060,6 +2713,8 @@ slot_sweep(rb_objspace_t *objspace, struct heaps_slot *sweep_slot)
+@@ -2061,6 +2714,8 @@ slot_sweep(rb_objspace_t *objspace, struct heaps_slot *sweep_slot)
          sweep_slot->limit = final_num;
          freelist = free;	/* cancel this page from freelist */
          unlink_heap_slot(objspace, sweep_slot);
@@ -910,7 +913,7 @@ index e65d0ec..74ebec6 100644
      }
      else {
          objspace->heap.free_num += free_num;
-@@ -2072,6 +2727,10 @@ slot_sweep(rb_objspace_t *objspace, struct heaps_slot *sweep_slot)
+@@ -2073,6 +2728,10 @@ slot_sweep(rb_objspace_t *objspace, struct heaps_slot *sweep_slot)
              RUBY_VM_SET_FINALIZER_INTERRUPT(th);
          }
      }
@@ -921,7 +924,7 @@ index e65d0ec..74ebec6 100644
  }
  
  static int
-@@ -2092,6 +2751,21 @@ ready_to_gc(rb_objspace_t *objspace)
+@@ -2093,6 +2752,21 @@ ready_to_gc(rb_objspace_t *objspace)
  static void
  before_gc_sweep(rb_objspace_t *objspace)
  {
@@ -943,7 +946,7 @@ index e65d0ec..74ebec6 100644
      freelist = 0;
      objspace->heap.do_heap_free = (size_t)((heaps_used * HEAP_OBJ_LIMIT) * 0.65);
      objspace->heap.free_min = (size_t)((heaps_used * HEAP_OBJ_LIMIT)  * 0.2);
-@@ -2111,8 +2785,13 @@ before_gc_sweep(rb_objspace_t *objspace)
+@@ -2112,8 +2786,13 @@ before_gc_sweep(rb_objspace_t *objspace)
  static void
  after_gc_sweep(rb_objspace_t *objspace)
  {
@@ -957,7 +960,7 @@ index e65d0ec..74ebec6 100644
      if (objspace->heap.free_num < objspace->heap.free_min) {
          set_heaps_increment(objspace);
          heaps_increment(objspace);
-@@ -2125,6 +2804,29 @@ after_gc_sweep(rb_objspace_t *objspace)
+@@ -2126,6 +2805,29 @@ after_gc_sweep(rb_objspace_t *objspace)
      malloc_increase = 0;
  
      free_unused_heaps(objspace);
@@ -987,7 +990,7 @@ index e65d0ec..74ebec6 100644
  }
  
  static int
-@@ -2158,9 +2860,11 @@ rest_sweep(rb_objspace_t *objspace)
+@@ -2159,9 +2861,11 @@ rest_sweep(rb_objspace_t *objspace)
  
  static void gc_marks(rb_objspace_t *objspace);
  
@@ -999,7 +1002,7 @@ index e65d0ec..74ebec6 100644
      int res;
      INIT_GC_PROF_PARAMS;
  
-@@ -2182,7 +2886,6 @@ gc_lazy_sweep(rb_objspace_t *objspace)
+@@ -2183,7 +2887,6 @@ gc_lazy_sweep(rb_objspace_t *objspace)
              GC_PROF_TIMER_STOP(Qfalse);
              return res;
          }
@@ -1007,7 +1010,7 @@ index e65d0ec..74ebec6 100644
      }
      else {
          if (heaps_increment(objspace)) {
-@@ -2190,6 +2893,18 @@ gc_lazy_sweep(rb_objspace_t *objspace)
+@@ -2191,6 +2894,18 @@ gc_lazy_sweep(rb_objspace_t *objspace)
              return TRUE;
          }
      }
@@ -1026,7 +1029,7 @@ index e65d0ec..74ebec6 100644
  
      gc_marks(objspace);
  
-@@ -2198,6 +2913,10 @@ gc_lazy_sweep(rb_objspace_t *objspace)
+@@ -2199,6 +2914,10 @@ gc_lazy_sweep(rb_objspace_t *objspace)
  	set_heaps_increment(objspace);
      }
  
@@ -1037,7 +1040,7 @@ index e65d0ec..74ebec6 100644
      GC_PROF_SWEEP_TIMER_START;
      if(!(res = lazy_sweep(objspace))) {
          after_gc_sweep(objspace);
-@@ -2209,6 +2928,7 @@ gc_lazy_sweep(rb_objspace_t *objspace)
+@@ -2210,6 +2929,7 @@ gc_lazy_sweep(rb_objspace_t *objspace)
      GC_PROF_SWEEP_TIMER_STOP;
  
      GC_PROF_TIMER_STOP(Qtrue);
@@ -1045,24 +1048,14 @@ index e65d0ec..74ebec6 100644
      return res;
  }
  
-@@ -2435,9 +3155,15 @@ gc_marks(rb_objspace_t *objspace)
+@@ -2458,5 +3184,5 @@ gc_marks(rb_objspace_t *objspace)
      rb_thread_t *th = GET_THREAD();
      GC_PROF_MARK_TIMER_START;
- 
-+    /*
-+    if (gc_statistics & verbose_gc_stats) {
-+        fprintf(gc_data_file, "Marking objects\n");
-+    }
-+    */
-+
-     objspace->heap.live_num = 0;
-     objspace->count++;
 -
 +    live_objects = 0;
- 
-     SET_STACK_END;
- 
-@@ -2477,11 +3203,15 @@ gc_marks(rb_objspace_t *objspace)
+     objspace->heap.live_num = 0;
+     objspace->count++;
+@@ -2502,11 +3226,15 @@ gc_marks(rb_objspace_t *objspace)
  	}
      }
      GC_PROF_MARK_TIMER_STOP;
@@ -1078,9 +1071,9 @@ index e65d0ec..74ebec6 100644
      INIT_GC_PROF_PARAMS;
  
      if (GC_NOTIFY) printf("start garbage_collect()\n");
-@@ -2497,15 +3227,31 @@ garbage_collect(rb_objspace_t *objspace)
+@@ -2520,15 +3250,31 @@ garbage_collect(rb_objspace_t *objspace)
  
-     rest_sweep(objspace);
+     GC_PROF_TIMER_START;
  
 +    if (gc_statistics) {
 +        gc_time_accumulator_before_gc = gc_time_accumulator;
@@ -1110,7 +1103,7 @@ index e65d0ec..74ebec6 100644
      return TRUE;
  }
  
-@@ -2994,6 +3740,39 @@ rb_gc_call_finalizer_at_exit(void)
+@@ -3017,6 +3763,39 @@ rb_gc_call_finalizer_at_exit(void)
      rb_objspace_call_finalizer(&rb_objspace);
  }
  
@@ -1150,7 +1143,7 @@ index e65d0ec..74ebec6 100644
  static void
  rb_objspace_call_finalizer(rb_objspace_t *objspace)
  {
-@@ -3307,6 +4086,49 @@ count_objects(int argc, VALUE *argv, VALUE os)
+@@ -3330,6 +4109,51 @@ count_objects(int argc, VALUE *argv, VALUE os)
      return hash;
  }
  
@@ -1167,6 +1160,7 @@ index e65d0ec..74ebec6 100644
 +    return ULONG2NUM(live_objects);
 +}
 +
++RUBY_FUNC_EXPORTED
 +unsigned long rb_os_live_objects()
 +{
 +    rb_objspace_t *objspace = &rb_objspace;
@@ -1191,6 +1185,7 @@ index e65d0ec..74ebec6 100644
 +#endif
 +}
 +
++RUBY_FUNC_EXPORTED
 +unsigned LONG_LONG rb_os_allocated_objects()
 +{
 +    rb_objspace_t *objspace = &rb_objspace;
@@ -1200,7 +1195,7 @@ index e65d0ec..74ebec6 100644
  /*
   *  call-seq:
   *     GC.count -> Integer
-@@ -3599,6 +4421,28 @@ Init_GC(void)
+@@ -3622,6 +4421,28 @@ Init_GC(void)
      rb_define_singleton_method(rb_mGC, "stat", gc_stat, -1);
      rb_define_method(rb_mGC, "garbage_collect", rb_gc_start, 0);
  
@@ -1229,7 +1224,7 @@ index e65d0ec..74ebec6 100644
      rb_mProfiler = rb_define_module_under(rb_mGC, "Profiler");
      rb_define_singleton_method(rb_mProfiler, "enabled?", gc_profile_enable_get, 0);
      rb_define_singleton_method(rb_mProfiler, "enable", gc_profile_enable, 0);
-@@ -3612,6 +4456,9 @@ Init_GC(void)
+@@ -3635,6 +4456,9 @@ Init_GC(void)
      rb_define_module_function(rb_mObSpace, "each_object", os_each_obj, -1);
      rb_define_module_function(rb_mObSpace, "garbage_collect", rb_gc_start, 0);
  


### PR DESCRIPTION
Ruby-prof at the moment uses rb_os_allocated_objects, rb_gc_allocated_size, rb_gc_collections and rb_gc_time for it's memory profiles.
But these were exported as private symbols (at least on mac os lion, x64), this patch fixes it.

Also fixed line numbers so no more fuzzy-matching during patch.
