### PR TITLE
Add missing date in 2.1.1 backport patch.

### DIFF
--- a/patches/ruby/2.1.0/railsexpress/01-current-2.1.1-fixes.patch
+++ b/patches/ruby/2.1.0/railsexpress/01-current-2.1.1-fixes.patch
@@ -344,7 +344,7 @@ index 676e05b..7be9d72 100644
  # -*- ruby -*-
 -_VERSION = "1.2.3"
 +_VERSION = "1.2.4"
- date = %w$Date::                           $[1]
+ date = %w$Date:: 2013-11-26 11:23:13 +0900#$[1]
  
  Gem::Specification.new do |s|
 diff --git a/ext/openssl/ossl_ssl.c b/ext/openssl/ossl_ssl.c


### PR DESCRIPTION
Without the date, we can't apply the patch with the `patch` command.

The patch fails when trying to modify the `ext/bigdecimal/bigdecimal.gemspec`, and it generates the file `ext/bigdecimal/bigdecimal.gemspec.rej` with the following content:

```
***************
*** 1,5 ****
  # -*- ruby -*-
- _VERSION = "1.2.3"
  date = %w$Date::                           $[1]

  Gem::Specification.new do |s|
--- 1,5 ----
  # -*- ruby -*-
+ _VERSION = "1.2.4"
  date = %w$Date::                           $[1]

  Gem::Specification.new do |s|
```

You can see the output of the command `patch -p1 < patches/ruby/2.1.0/railsexpress/01-current-2.1.1-fixes.patch` here https://gist.github.com/jhbabon/8918392

If you check the original `ext/bigdecimal/bigdecimal.gemspec` from the ruby 2.1.0 source code, it has a different line under the changed `_VERSION` constant.
