### PR TITLE
patch configure and configure.in to make ruby 2.2.0 compile on debian/lenny

### DIFF
--- a/patches/ruby/2.2.0/railsexpress/05-fix-packed-bitfield-compat-warning-for-older-gccs.patch
+++ b/patches/ruby/2.2.0/railsexpress/05-fix-packed-bitfield-compat-warning-for-older-gccs.patch
@@ -1,7 +1,27 @@
-diff --git a/configure.in b/configure.in
-index 375ef55..a69ded7 100644
---- a/configure.in
-+++ b/configure.in
+diff -rupN a/configure b/configure
+--- a/configure	2015-01-07 07:23:23.420553467 +0000
++++ b/configure	2015-01-07 07:20:57.769700633 +0000
+@@ -7471,6 +7471,9 @@ rb_cv_warnflags="$warnflags"
+ if test "$GCC:${warnflags+set}:no" = yes::no; then
+     if test $gcc_major -ge 4; then
+ 	extra_warning=-Werror=extra-tokens
++        if test $gcc_major -gt 4 -o $gcc_minor -ge 4; then
++            extra_warning="$extra_warning -Wno-packed-bitfield-compat"
++        fi
+     else
+ 	extra_warning=
+     fi
+@@ -7484,7 +7487,6 @@ if test "$GCC:${warnflags+set}:no" = yes
+ 		 -Werror=implicit-function-declaration \
+ 		 -Werror=division-by-zero \
+ 		 -Werror=deprecated-declarations \
+-		 -Wno-packed-bitfield-compat \
+ 		 $extra_warning \
+ 		 ; do
+ 	if test "$particular_werror_flags" != yes; then
+diff -rupN a/configure.in b/configure.in
+--- a/configure.in	2015-01-07 07:23:42.308923341 +0000
++++ b/configure.in	2015-01-07 07:24:22.365708146 +0000
 @@ -788,6 +788,9 @@ rb_cv_warnflags="$warnflags"
  if test "$GCC:${warnflags+set}:no" = yes::no; then
      if test $gcc_major -ge 4; then
@@ -12,3 +32,11 @@ index 375ef55..a69ded7 100644
      else
  	extra_warning=
      fi
+@@ -801,7 +804,6 @@ if test "$GCC:${warnflags+set}:no" = yes
+ 		 -Werror=implicit-function-declaration \
+ 		 -Werror=division-by-zero \
+ 		 -Werror=deprecated-declarations \
+-		 -Wno-packed-bitfield-compat \
+ 		 $extra_warning \
+ 		 ; do
+ 	if test "$particular_werror_flags" != yes; then


### PR DESCRIPTION
Hi Stefan,

we need to remove '-Wno-packed-bitfield-compat' from the for loop options as well. And, as the configure file is included in the ruby-2.2.0 tar archive, we need to patch this file too.

Please review and merge if ok for you.

Cheers
Dennis