### PR TITLE
Backport bugfix for 2.2.2p133 parser regression

### DIFF
--- a/patches/ruby/2.2.2/railsexpress/05-fix-backports-parser-regression.patch
+++ b/patches/ruby/2.2.2/railsexpress/05-fix-backports-parser-regression.patch
@@ -1,0 +1,41 @@
+diff --git a/ChangeLog b/ChangeLog
+index 9841627..3500817 100644
+--- a/ChangeLog
++++ b/ChangeLog
+@@ -1,3 +1,8 @@
++Thu Jul 23 09:05:28 2015  Nobuyoshi Nakada  <nobu@ruby-lang.org>
++
++	* parse.y (lambda_body): pop cmdarg stack for lookahead
++	  token.  [ruby-core:70067] [Bug #11380]
++
+ Thu Jul 23 04:03:03 2015  Aaron Patterson <tenderlove@ruby-lang.org>
+ 
+ 	* ext/openssl/ossl_ssl.c: fix tests by not setting the instance
+diff --git a/parse.y b/parse.y
+index 7f693fe..fe62426 100644
+--- a/parse.y
++++ b/parse.y
+@@ -3524,6 +3524,7 @@ lambda		:   {
+ 		    {
+ 			lpar_beg = $<num>2;
+ 			cmdarg_stack = $<val>5;
++			CMDARG_LEXPOP();
+ 		    /*%%%*/
+ 			$$ = NEW_LAMBDA($3, $6);
+ 			nd_set_line($$, $<num>4);
+diff --git a/test/ruby/test_syntax.rb b/test/ruby/test_syntax.rb
+index 189cf13..158c12d 100644
+--- a/test/ruby/test_syntax.rb
++++ b/test/ruby/test_syntax.rb
+@@ -414,6 +414,11 @@ def test_do_block_in_lambda
+     assert_valid_syntax('p ->() do a() do end end', bug11107)
+   end
+ 
++  def test_do_block_after_lambda
++    bug11380 = '[ruby-core:70067] [Bug #11380]'
++    assert_valid_syntax('p -> { :hello }, a: 1 do end', bug11380)
++  end
++
+   def test_reserved_method_no_args
+     bug6403 = '[ruby-dev:45626]'
+     assert_valid_syntax("def self; :foo; end", __FILE__, bug6403)

--- a/patchsets/ruby/2.2.2/railsexpress
+++ b/patchsets/ruby/2.2.2/railsexpress
@@ -2,3 +2,4 @@ railsexpress/01-zero-broken-tests.patch
 railsexpress/02-improve-gc-stats.patch
 railsexpress/03-display-more-detailed-stack-trace.patch
 railsexpress/04-backported-bugfixes-222.patch
+railsexpress/05-fix-backports-parser-regression.patch


### PR DESCRIPTION
This fixes bug 11380 introduced by bug 11107 which was backported in patch 04-backported-bugfixes-222.patch. Fixes #39.

Commit taken from trunk, because it's not yet backported to ruby_2_2 branch.